### PR TITLE
fix: set bash on windows ci

### DIFF
--- a/.github/workflows/create_release-and-upload.yml
+++ b/.github/workflows/create_release-and-upload.yml
@@ -66,6 +66,7 @@ jobs:
     - name: output url
       id: get_url
       run: echo "upload_url=${{ needs.create_releases.outputs.release_url }}" >> $GITHUB_OUTPUT
+      shell: bash
     - name: Get the version
       id: get_version
       run: echo "VERSION=${GITHUB_REF/refs\/tags\///}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Linked Issue

<!--
for linked ZenHub Issue or other repository issue.
  - ZenHub's issue URL
  - other repository's issue URL
-->

## Overview

- fix: set bash on windows ci

## How to use

<!-- 
- How to check the operation
  - For tasks that require operation confirmation, enter the required commands, etc.
  - If not needed, leave blank
-->

```bash
```

## Items reserved this time, or TODO

<!--
- If not needed, leave blank
-->

## Check list

** Person who issued **
- [ ] checked script <!-- npm run check -->
- [ ] build successed
- [ ] Linked PullRequest and Issue

** Reviewer **
- [ ] (if necessary) Record the review results of related tickets.

## Memo

<!--
- Explain any considerations or considerations.
-->
